### PR TITLE
Fix global recipe queue type definition

### DIFF
--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,10 +1,33 @@
 export {};
 
+interface RecipeNutritionInfo {
+  calories: number;
+  protein: string;
+  carbs: string;
+  fat: string;
+}
+
+interface RecipeDisplayData {
+  id: string;
+  title: string;
+  description: string;
+  cuisine: string;
+  difficulty: "Easy" | "Medium" | "Hard";
+  cookTime: string;
+  prepTime: string;
+  servings: number;
+  ingredients: string[];
+  instructions: string[];
+  image?: string;
+  nutrition?: RecipeNutritionInfo;
+  tags?: string[];
+}
+
 interface RecipeDisplayQueueItem {
   id: string;
-  recipes: Array<unknown>;
+  recipes: RecipeDisplayData[];
   searchQuery?: string;
-  dietary?: string;
+  dietary?: string[];
   timestamp: number;
 }
 

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -31,8 +31,43 @@ interface RecipeDisplayQueueItem {
   timestamp: number;
 }
 
+interface BookingRestaurantInfo {
+  id: string;
+  name: string;
+  address: string;
+  phone: string;
+  cuisine: string;
+  rating?: number;
+  image?: string;
+}
+
+interface BookingDetails {
+  date: string;
+  time: string;
+  partySize: number;
+  specialRequests?: string;
+  customerName?: string;
+  customerPhone?: string;
+  customerEmail?: string;
+}
+
+interface RestaurantBookingData {
+  restaurant: BookingRestaurantInfo;
+  booking: BookingDetails;
+  confirmationNumber?: string;
+  status: "pending" | "confirmed" | "cancelled";
+}
+
+interface BookingDisplayQueueItem {
+  id: string;
+  bookings: RestaurantBookingData[];
+  searchQuery?: string;
+  timestamp: number;
+}
+
 declare global {
   var recipeDisplayQueue: RecipeDisplayQueueItem[] | undefined;
+  var bookingDisplayQueue: BookingDisplayQueueItem[] | undefined;
 
   interface SpeechRecognitionResultAlternative {
     transcript: string;

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,6 +1,16 @@
 export {};
 
+interface RecipeDisplayQueueItem {
+  id: string;
+  recipes: Array<unknown>;
+  searchQuery?: string;
+  dietary?: string;
+  timestamp: number;
+}
+
 declare global {
+  var recipeDisplayQueue: RecipeDisplayQueueItem[] | undefined;
+
   interface SpeechRecognitionResultAlternative {
     transcript: string;
     confidence: number;


### PR DESCRIPTION
## Summary
- add a typed RecipeDisplayQueueItem interface to the shared global declarations
- declare the recipeDisplayQueue global so the polling endpoint can build with type safety

## Testing
- npm run build *(fails: unable to download Google Fonts in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d85917017c8330b544f6e9dc0e4253